### PR TITLE
feat: run test mode on PR trigger

### DIFF
--- a/.github/workflows/test_bot.yaml
+++ b/.github/workflows/test_bot.yaml
@@ -2,11 +2,13 @@ name: Test Bot
 
 on:
   workflow_dispatch:
+  pull_request:
+    types: [opened, reopened, synchronize]
 
 # Concurrency group to prevent parallel runs
 concurrency:
-  group: ${{ github.workflow }}
-  cancel-in-progress: false
+  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+  cancel-in-progress: true
 
 # This job is for testing and has no cron, so it will run only once
 jobs:


### PR DESCRIPTION
## **Changes**
- Trigger bot test workflow on PR
  - Cancel overlapping PR builds, but let scheduled jobs always run